### PR TITLE
README: more detail on the MGN9 rail length, and shorter rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Bat XY joints (for set of 2):
   * 6x M3 nuts
   * 8x F623 bearings
 * New parts to buy
-  * 200mm MGN9H rail: high-preload (Z1)
-    * Rails can be slightly shorter (up to 50mm) and may work fine, by using the innermost two screws, instead of 3.
+  * 200mm MGN9H rail: high-preload (Z1) - note that this is 50mm longer than the v0 BOM rails.
+    * Rails can be slightly shorter (up to 50mm) and may work fine, by using the innermost two screws, instead of 3.  There is less rotational support for the rail, but this has been measured at under 0.3° which should not cause adverse effects.
   * 6x M3x8 SHCS
   * Pins Option
     * 4x 3mmx30mm Steel pins


### PR DESCRIPTION
Discovered this the hard way.  I did not notice that the rail length was    longer than the v0 spec, so ordered an MGN9 rail the same length as my    previous MGN7 one.  This meant I was using the middle two screwholes    instead of three as described here in the BOM.  The deflection from the    the DragonBrick toolhead in this configuration was measured at 0.2° ±    0.1°.  Note these experiences in the relevant hint, and also make it    really clear that the rail length differs from the v0 BOM spec.

Suggested edits below.